### PR TITLE
Fix the handling of the html_sanitizer service for the main serializer

### DIFF
--- a/src/DependencyInjection/HtmlSanitizerExtension.php
+++ b/src/DependencyInjection/HtmlSanitizerExtension.php
@@ -81,7 +81,7 @@ class HtmlSanitizerExtension extends Extension
 
             if ($name === $default) {
                 $container->setAlias(SanitizerInterface::class, 'html_sanitizer.'.$name);
-                $container->setDefinition('html_sanitizer', $definition);
+                $container->setAlias('html_sanitizer', 'html_sanitizer.'.$name);
             }
 
             $refMap[$name] = new ServiceClosureArgument(new Reference('html_sanitizer.'.$name));


### PR DESCRIPTION
It should be an alias of the named service, instead of being a separate sanitizer instance using the same definition.