### PR TITLE
Fix compatibility with Symfony 5.0

### DIFF
--- a/src/Form/TextTypeExtension.php
+++ b/src/Form/TextTypeExtension.php
@@ -36,10 +36,12 @@ class TextTypeExtension extends AbstractTypeExtension
     // needed for BC reasons
     public function getExtendedType()
     {
-        return self::getExtendedTypes()[0];
+        foreach (static::getExtendedTypes() as $extendedType) {
+            return $extendedType;
+        }
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [TextType::class];
     }


### PR DESCRIPTION
Hi! I found this error testing Symfony 5.0 branch:
> Compile Error: Declaration of HtmlSanitizer\Bundle\Form\TextTypeExtension::getExtendedTypes() must be compatible with Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes(): iterable