### PR TITLE
fix(di): refers to the key to be able to override by env

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('default_sanitizer')->isRequired()->end()
                 ->arrayNode('sanitizers')
                     ->isRequired()
+                    ->useAttributeAsKey('name')
                     ->prototype('variable')->end()
                     ->defaultValue([])
                 ->end()


### PR DESCRIPTION
When we try to override the configuration (like for dev/test env) we got this error :
```sh
In ContainerBuilder.php line 1381:
                                                                               
  Invalid argument name "0" for service "html_sanitizer.0": the first character must be a letter. 
```
Symfony documentation explain : 
![image](https://user-images.githubusercontent.com/2004449/109015898-e3ec3b80-76b5-11eb-8f66-33d2aafcbf96.png)

