### PR TITLE
Fix a deprecation message about a missing return type

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,6 +21,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('html_sanitizer');


### PR DESCRIPTION
This fixes the following deprecation:

```
  1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "HtmlSanitizer\Bundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AddUserCommandTest::testCreateUserNonInteractive from App\Tests\Command
```

which we found when upgrading Symfony Demo app to the upcoming Symfony 5.4. See https://github.com/symfony/demo/pull/1268#issuecomment-961933724