### PR TITLE
Fixes multiple symfony deprecation warnings

### DIFF
--- a/src/DependencyInjection/CompilerPass/RegisterUserExtensionsCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/RegisterUserExtensionsCompilerPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterUserExtensionsCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $builder = $container->getDefinition('html_sanitizer.builder');
         foreach ($container->findTaggedServiceIds('html_sanitizer.extension') as $serviceId => $tags) {

--- a/src/DependencyInjection/HtmlSanitizerExtension.php
+++ b/src/DependencyInjection/HtmlSanitizerExtension.php
@@ -33,7 +33,7 @@ use Twig\Environment;
  */
 class HtmlSanitizerExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Form/TextTypeExtension.php
+++ b/src/Form/TextTypeExtension.php
@@ -46,7 +46,7 @@ class TextTypeExtension extends AbstractTypeExtension
         return [TextType::class];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults(['sanitize_html' => false, 'sanitizer' => null])
@@ -55,7 +55,7 @@ class TextTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($options['sanitize_html']) {
             $builder->addEventListener(


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "HtmlSanitizer\Bundle\DependencyInjection\HtmlSanitizerExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "HtmlSanitizer\Bundle\DependencyInjection\CompilerPass\RegisterUserExtensionsCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Form\AbstractTypeExtension::configureOptions()" might add "void" as a native return type declaration in the future. Do the same in child class "HtmlSanitizer\Bundle\Form\TextTypeExtension" now to avoid errors or add an explicit @return annotation to suppress this message.


Method "Symfony\Component\Form\AbstractTypeExtension::buildForm()" might add "void" as a native return type declaration in the future. Do the same in child class "HtmlSanitizer\Bundle\Form\TextTypeExtension" now to avoid errors or add an explicit @return annotation to suppress this message.